### PR TITLE
Use beta content url for beta version extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
       - run: git clone git@github.com:Rise-Vision/private-keys.git
       - run: npm install
       - run:
+          name: Set staging url for content
+          command: npm run set-staging-content
+      - run:
           name: Deploy to beta (test Web Store account)
           command: |
             npm run test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Do the five! Stop the spread of the coronavirus every time you open a new tab.",
   "scripts": {
+    "set-staging-content": "sed -i 's/dothefive\\/index.html/dothefive\\/staging\\/index.html/' src/newtab.html",
     "test": "eslint src",
     "build": "cd src && zip -r package * && mv package.zip ..",
     "predeploy": "npm run build",


### PR DESCRIPTION
## Description
Use beta content url for staging

## Motivation and Context
Keep content and extension beta/stable releases in sync

## How Has This Been Tested?
Locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
